### PR TITLE
Rename CI workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,4 +1,4 @@
-name: CI
+name: tests
 on: [push]
 jobs:
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # go-dreamhost
 
+[![Test Status](https://github.com/sgerrand/go-dreamhost/workflows/tests/badge.svg)](https://github.com/sgerrand/go-dreamhost/actions?query=workflow%3Atests)
+
 `go-dreamhost` is a Go library for accessing the [Dreamhost
 API](https://help.dreamhost.com/hc/en-us/articles/217560167).
 


### PR DESCRIPTION
💁 The previous name was inconsistent between that specified in the filename versus that used through URLs.