### PR TITLE
Code coverage

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,7 +20,12 @@ jobs:
       run: go get -v -t -d ./...
 
     - name: Run tests
-      run: go test -bench -v ./...
+      run: go test -v -race -coverprofile=coverage.txt -covermode=atomic ./...
+
+    - name: Upload coverage to Codecov
+      env:
+        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+      run: bash <(curl -s https://codecov.io/bash)
 
   lint:
     name: Lint

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # go-dreamhost
 
 [![Test Status](https://github.com/sgerrand/go-dreamhost/workflows/tests/badge.svg)](https://github.com/sgerrand/go-dreamhost/actions?query=workflow%3Atests)
+[![Test Coverage](https://codecov.io/gh/sgerrand/go-dreamhost/branch/master/graph/badge.svg)](https://codecov.io/gh/sgerrand/go-dreamhost)
 
 `go-dreamhost` is a Go library for accessing the [Dreamhost
 API](https://help.dreamhost.com/hc/en-us/articles/217560167).


### PR DESCRIPTION
💁 Generates and publishes code coverage metrics to [CodeCov](https://codecov.io/gh/sgerrand/go-dreamhost). Implemented as per the [published example for Go](https://github.com/codecov/example-go).